### PR TITLE
Numeric SteamID64 conversion error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -99,7 +99,7 @@ export class ID {
         } else if (isNaN(input)) {
             throw new Error(`Unknown SteamID input format "${input}"`);
         } else {
-            const x = new UInt64(input, 10);
+            const x = new UInt64(input.toString(), 10);
             this.format    = 'steam64';
             this.accountid = (x.toNumber() & 0xFFFFFFFF) >>> 0;
             this.instance  = x.shiftRight(32).toNumber() & 0xFFFFF;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1691,9 +1691,9 @@ lodash.merge@^4.6.1:
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 lodash@^4.17.13, lodash@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 log-symbols@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
There is a problem in the conversion of SteamId64s that accour if the provided input is passed as a number.
a simple ".toString()" solves this problem.